### PR TITLE
Handle confidence levels

### DIFF
--- a/sim/resources/minintervalschedule.py
+++ b/sim/resources/minintervalschedule.py
@@ -9,18 +9,18 @@ from api.common.controller.DataFrame import DataFrame
 
 
 # temp mock up datatype
-'''class DataFrame:
-    def __init__(self, data: List[int], intervals: List[Tuple[int, int]]):
-        self.data = data
-        self.intervals = intervals
+# class DataFrame:
+#     def __init__(self, data: List[int], intervals: List[Tuple[int, int]]):
+#         self.data = data
+#         self.intervals = intervals
 
-    def get_interval_sample(self, i: int):
-        start, end = self.intervals[i]
-        return self.data[start: end]
+#     def get_interval_sample(self, i: int):
+#         start, end = self.intervals[i]
+#         return self.data[start: end]
 
-    def get_interval_size(self, i: int):
-        start, end = self.intervals[i]
-        return end - start'''
+#     def get_interval_size(self, i: int):
+#         start, end = self.intervals[i]
+#         return end - start
 
 
 class SimulationResults:
@@ -60,14 +60,24 @@ def gen_min_interval_slots(data_frame: DataFrame, window: float, min_ratio: floa
     :return: the results of the simulation, or None if schedule is infeasible
     """
 
+    # parameter checking
     if num_sim_runs <= 0:
         raise ValueError('Invalid simulation run value specified')
-
-    if final_window < window or min_ratio == 1.:
+    elif final_window < window or min_ratio == 1.:
         raise ValueError('Invalid final window and window value supplied')
+    elif min_ratio > 1:
+        raise ValueError('min_ratio should be a float between 0 and 1 inclusive')
+    elif confidence >= 100:
+        raise ValueError('confidence must be a number beween 0 inclusive and 100 exclusive')
+    elif start < 0:
+        raise ValueError('invalid value for the starting index of the first interval. Must be an integer >= 0')
 
-    expected_slots: List[SimulationResults] = []
+    # setup default values
+    if queue == None:
+        queue = deque()
+
     # simulate each interval
+    expected_slots: List[SimulationResults] = []
     for interval in range(len(data_frame.intervals)):
         interval_schedule = _opt_interval_schedule(queue=queue, data_frame=data_frame, interval=interval,
                                                    min_ratio=min_ratio, window=window, final_window=final_window,
@@ -115,13 +125,25 @@ def _opt_interval_schedule(queue: deque, data_frame: DataFrame, interval: int, m
         allocations.append(allocation)
     # calculate the resulting queue for N*
     opt = math.ceil(np.percentile(allocations, confidence))
-    sample_arrival = data_frame.get_interval_sample(interval)
-    schedule_with_padding = _gen_uniform_suggested_schedule(arrivals=sample_arrival, allocation_amount=opt, window=window)
 
-    interval_size_schedule = schedule_with_padding[:data_frame.get_interval_size(interval)]
-    schedule_sim_result = simulate_allocations(arrivals=sample_arrival, slot_schedule=interval_size_schedule,
-                                               current_queue=queue, offset=offset)
-    opt_allocation = AllocationResult(opt, schedule_sim_result.remainder_queue)
+    # get the remainder queue for the next interval by getting the confidence percentile of remainder queues
+    remainder_queues: deque = []
+    for _ in range(num_sim_runs):
+        stochastic_arrivals = data_frame.get_interval_sample(interval)
+        schedule_with_padding = _gen_uniform_suggested_schedule(arrivals=stochastic_arrivals, allocation_amount=opt, window=window)
+        interval_size_schedule = schedule_with_padding[:data_frame.get_interval_size(interval)]
+        schedule_sim_result = simulate_allocations(arrivals=stochastic_arrivals, slot_schedule=interval_size_schedule,
+                                                   current_queue=queue, offset=offset)
+        print(schedule_sim_result.remainder_queue)
+        remainder_queues.append(schedule_sim_result.remainder_queue)
+    # remainder queue index corresponding to N* is the confidence-level percentile index
+    opt_remainder_queue_index = math.ceil(confidence / 100 * len(remainder_queues)) - 1
+    print("reran queues: ", remainder_queues, opt_remainder_queue_index)
+    # sort by largest carryover size
+    # TODO: investigate whether sorting by size is best, and if the sequence of values in a queue has an effect
+    sorted(remainder_queues, key = lambda e : sum([remainder for time, remainder in e]))
+    opt_remainder_queue = remainder_queues[opt_remainder_queue_index]
+    opt_allocation = AllocationResult(opt, opt_remainder_queue)
     return opt_allocation
 
 

--- a/sim/tests/minintervalschedule/test__opt_interval_schedule.py
+++ b/sim/tests/minintervalschedule/test__opt_interval_schedule.py
@@ -1,5 +1,41 @@
 from sim.resources import minintervalschedule as gas
 from collections import deque
+import numpy as np
+
+# mock data frame whereby the sample generated is the same per iteration of simulation run
+# (makes it easier/more consistent for debugging tests since the N* calculating arrivals are the same as
+# the corresponding remainder queue arrivals)
+class DataFrame:
+    def __init__(self, arrivals, intervals, num_sim_runs):
+        self.intervals = intervals
+        self.arrivals = arrivals
+        self.invoke_count = 0
+        self.num_sim_runs = num_sim_runs
+
+    def get_interval_size(self, interval):
+        # Check validity of input interval index.
+        if interval not in range(0, len(self.intervals)):
+            raise ValueError("Invalid interval %s.", interval)
+
+        # Return the length of a given interval
+        return self.intervals[interval][1] - self.intervals[interval][0]
+    
+    def get_interval_sample(self, interval):
+        # Check validity of input interval index.
+        if interval not in range(0, len(self.intervals)):
+            raise ValueError("Invalid interval %s.", interval)
+        
+        # Get start and end of interval
+        start = self.intervals[interval][0]
+        end = self.intervals[interval][1]
+        
+        # Generate and return sample
+        mock_rand_variance = 1
+        res = [mock_rand_variance * self.invoke_count + a for a in self.arrivals[start:end]]
+        print('arrivals: ', res)
+        self.invoke_count += 1
+        if self.invoke_count >= self.num_sim_runs: self.invoke_count = 0 
+        return res
 
 
 def test_creates_correct_remainder():
@@ -51,4 +87,50 @@ def test_creates_correct_remainder_queue_after_multiple_intervals():
                                            num_sim_runs=num_sim_runs, confidence=confidence)
     assert len(schedule2.remainder_queue) == 1
     assert schedule2.remainder_queue[0] == [3, 2]
+
+def test_confidence():
+    # CAREFUL WITH EDITING THIS TEST
+    # check the queue for a single sim run for a particular schedule
+    queue = deque()
+    min_ratio = 0.8
+    window = 0.
+    final_window = 2.
+    num_sim_runs = 1
+    confidence = 90
+    data_frame = DataFrame([13, 15, 4, 8, 6, 4, 5, 7, 7], [(0, 2), (2, 4), (4, 7), (7, 9)], num_sim_runs)
+    schedule1 = gas._opt_interval_schedule(queue=queue, data_frame=data_frame, interval=0, min_ratio=min_ratio,
+                                           window=window, final_window=final_window, num_sim_runs=num_sim_runs,
+                                           confidence=confidence)
+    assert len(schedule1.remainder_queue) == 1
+    assert schedule1.remainder_queue[0] == [1, 4]
+
+    # test for multiple sim runs
+    # CAREFUL with test!!! Variance is calculated based on num of sim runs
+    queue = deque()
+    min_ratio = 0.8
+    window = 0.
+    final_window = 2.
+    num_sim_runs = 6
+    confidence = 90
+    data_frame = DataFrame([9, 11, 4, 8, 6, 4, 5, 7, 7], [(0, 2), (2, 4), (4, 7), (7, 9)], num_sim_runs)
+    schedule1 = gas._opt_interval_schedule(queue=queue, data_frame=data_frame, interval=0, min_ratio=min_ratio,
+                                           window=window, final_window=final_window, num_sim_runs=num_sim_runs,
+                                           confidence=confidence)
+    assert len(schedule1.remainder_queue) == 1
+    assert schedule1.remainder_queue[0] == [1, 4]
+
+    # LOW CONFIDENCE
+    queue = deque()
+    min_ratio = 0.8
+    window = 0.
+    final_window = 2.
+    num_sim_runs = 6
+    confidence = 50
+    data_frame = DataFrame([9, 11, 4, 8, 6, 4, 5, 7, 7], [(0, 2), (2, 4), (4, 7), (7, 9)], num_sim_runs)
+    schedule1 = gas._opt_interval_schedule(queue=queue, data_frame=data_frame, interval=0, min_ratio=min_ratio,
+                                           window=window, final_window=final_window, num_sim_runs=num_sim_runs,
+                                           confidence=confidence)
+    assert len(schedule1.remainder_queue) == 1
+    assert schedule1.remainder_queue[0] == [1, 2]
+
 


### PR DESCRIPTION
- handle confidence level in generating remainder queue for subsequent intervals
- more type checking
- optional imports because of circular dependency (backend imports sim and sim imports backend)

TODO: remove this circular dependency.